### PR TITLE
fix: refactor execute to return the correct Response type

### DIFF
--- a/src/lib/AskBuilder.ts
+++ b/src/lib/AskBuilder.ts
@@ -1,9 +1,10 @@
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlQuery, SparqlAskExecutable } from './index'
 import { ask } from './execute'
 import LIMIT, { LimitOffsetBuilder } from './partials/LIMIT'
 
-type AskQuery = SparqlQuery<boolean>
+type AskQuery = SparqlQuery
+& SparqlAskExecutable
 & LimitOffsetBuilder<AskQuery> & {
   readonly patterns: SparqlTemplateResult
 }

--- a/src/lib/ConstructBuilder.ts
+++ b/src/lib/ConstructBuilder.ts
@@ -1,10 +1,13 @@
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlGraphQueryExecutable, SparqlQuery } from './index'
 import { graph } from './execute'
 import WHERE, { WhereBuilder } from './partials/WHERE'
 import LIMIT, { LimitOffsetBuilder } from './partials/LIMIT'
 
-type ConstructQuery = SparqlQuery<Response> & WhereBuilder<ConstructQuery> & LimitOffsetBuilder<ConstructQuery> & {
+type ConstructQuery = SparqlQuery
+& SparqlGraphQueryExecutable
+& WhereBuilder<ConstructQuery>
+& LimitOffsetBuilder<ConstructQuery> & {
   readonly constructTemplate: SparqlTemplateResult
 }
 

--- a/src/lib/DeleteBuilder.ts
+++ b/src/lib/DeleteBuilder.ts
@@ -2,13 +2,16 @@ import { Literal, NamedNode } from 'rdf-js'
 import { sparql, SparqlValue } from '@tpluscode/rdf-string'
 import { SparqlTemplateResult } from '@tpluscode/rdf-string/lib/sparql'
 import { update } from './execute'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlQuery, SparqlUpdateExecutable } from './index'
 import DATA, { QuadDataBuilder } from './partials/DATA'
 import WHERE, { WhereBuilder } from './partials/WHERE'
 import INSERT, { InsertBuilder } from './partials/INSERT'
 import { concat } from './TemplateResult'
 
-type DeleteInsertQuery = InsertBuilder<DeleteInsertQuery> & WhereBuilder<DeleteInsertQuery> & SparqlQuery<void> & {
+type DeleteInsertQuery = InsertBuilder<DeleteInsertQuery>
+& WhereBuilder<DeleteInsertQuery>
+& SparqlQuery
+& SparqlUpdateExecutable & {
   readonly deletePatterns: SparqlTemplateResult
   readonly with?: NamedNode
   readonly using?: NamedNode[]
@@ -16,7 +19,7 @@ type DeleteInsertQuery = InsertBuilder<DeleteInsertQuery> & WhereBuilder<DeleteI
   DELETE(strings: TemplateStringsArray, ...values: SparqlValue[]): DeleteInsertQuery
 }
 
-type DeleteData = SparqlQuery<void> & QuadDataBuilder<DeleteData, NamedNode | Literal>
+type DeleteData = SparqlQuery & SparqlUpdateExecutable & QuadDataBuilder<DeleteData, NamedNode | Literal>
 
 export const DELETE = (strings: TemplateStringsArray, ...values: SparqlValue[]): DeleteInsertQuery => ({
   ...Builder(),

--- a/src/lib/DescribeBuilder.ts
+++ b/src/lib/DescribeBuilder.ts
@@ -1,11 +1,14 @@
 import { NamedNode, Variable } from 'rdf-js'
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlGraphQueryExecutable, SparqlQuery } from './index'
 import { graph } from './execute'
 import WHERE, { WhereBuilder } from './partials/WHERE'
 import LIMIT, { LimitOffsetBuilder } from './partials/LIMIT'
 
-type DescribeQuery = SparqlQuery<Response> & WhereBuilder<DescribeQuery> & LimitOffsetBuilder<DescribeQuery> & {
+type DescribeQuery = SparqlQuery
+& SparqlGraphQueryExecutable
+& WhereBuilder<DescribeQuery>
+& LimitOffsetBuilder<DescribeQuery> & {
   readonly described: SparqlTemplateResult
 }
 

--- a/src/lib/InsertBuilder.ts
+++ b/src/lib/InsertBuilder.ts
@@ -1,18 +1,21 @@
 import { BlankNode, Literal, NamedNode } from 'rdf-js'
 import { sparql, SparqlValue } from '@tpluscode/rdf-string'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlQuery, SparqlUpdateExecutable } from './index'
 import { update } from './execute'
 import DATA, { QuadDataBuilder } from './partials/DATA'
 import WHERE, { WhereBuilder } from './partials/WHERE'
 import InsertBuilderPartial, { InsertBuilder } from './partials/INSERT'
 
-type InsertQuery = SparqlQuery<void> & InsertBuilder<InsertQuery> & WhereBuilder<InsertQuery> & {
+type InsertQuery = SparqlQuery
+& SparqlUpdateExecutable
+& InsertBuilder<InsertQuery>
+& WhereBuilder<InsertQuery> & {
   readonly with?: NamedNode
   readonly using?: NamedNode[]
   readonly usingNamed?: NamedNode[]
 }
 
-type InsertData = SparqlQuery<void> & QuadDataBuilder<InsertData, NamedNode | Literal | BlankNode>
+type InsertData = SparqlQuery & SparqlUpdateExecutable & QuadDataBuilder<InsertData, NamedNode | Literal | BlankNode>
 
 export const INSERT = (strings: TemplateStringsArray, ...values: SparqlValue[]): InsertQuery => ({
   ...Builder(),

--- a/src/lib/SelectBuilder.ts
+++ b/src/lib/SelectBuilder.ts
@@ -1,13 +1,14 @@
-import { DefaultGraph, NamedNode, Term, Variable } from 'rdf-js'
+import { DefaultGraph, NamedNode, Variable } from 'rdf-js'
 import { defaultGraph } from '@rdfjs/data-model'
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
 import { select } from './execute'
-import Builder, { SparqlQuery } from './index'
+import Builder, { SparqlQuery, SparqlQueryExecutable } from './index'
 import WHERE, { WhereBuilder } from './partials/WHERE'
 import LIMIT, { LimitOffsetBuilder } from './partials/LIMIT'
 import ORDER, { OrderBuilder } from './partials/ORDER'
 
-type SelectQuery = SparqlQuery<readonly Record<string, Term>[]>
+type SelectQuery = SparqlQuery
+& SparqlQueryExecutable
 & WhereBuilder<SelectQuery>
 & LimitOffsetBuilder<SelectQuery>
 & OrderBuilder<SelectQuery>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,31 +1,42 @@
 import { SparqlHttpClient } from 'sparql-http-client'
 import { SparqlTemplateResult } from '@tpluscode/rdf-string'
+import { Term } from 'rdf-js'
 
 interface SparqlBuildOptions {
   base?: string
 }
 
-export interface SparqlQueryBuilder {
+export interface SparqlQuery {
   build(options?: SparqlBuildOptions): string
   _getTemplateResult(): SparqlTemplateResult
 }
 
-export interface SparqlQueryExecutable<TResult> {
-  execute(client: SparqlHttpClient, requestInit?: RequestInit): Promise<TResult>
+export interface SparqlQueryExecutable {
+  execute(client: SparqlHttpClient, requestInit?: RequestInit): Promise<readonly Record<string, Term>[]>
 }
 
-export type SparqlQuery<T> = SparqlQueryBuilder & SparqlQueryExecutable<T>
+export interface SparqlGraphQueryExecutable {
+  execute<TResponse extends Response>(client: SparqlHttpClient<TResponse>, requestInit?: RequestInit): Promise<TResponse>
+}
 
-type Builder = Pick<SparqlQueryBuilder, 'build'> & Pick<SparqlTemplateResult, '_toPartialString'>
+export interface SparqlUpdateExecutable {
+  execute(client: SparqlHttpClient, requestInit?: RequestInit): Promise<void>
+}
 
-export default function Builder<T extends SparqlQueryBuilder>(): Builder {
+export interface SparqlAskExecutable {
+  execute(client: SparqlHttpClient, requestInit?: RequestInit): Promise<boolean>
+}
+
+type Builder = Pick<SparqlQuery, 'build'> & Pick<SparqlTemplateResult, '_toPartialString'>
+
+export default function Builder<T extends SparqlQuery>(): Builder {
   return {
-    build(this: SparqlQueryBuilder, { base }: SparqlBuildOptions = {}): string {
+    build(this: SparqlQuery, { base }: SparqlBuildOptions = {}): string {
       return this._getTemplateResult().toString({
         base,
       })
     },
-    _toPartialString(this: SparqlQueryBuilder, options: any) {
+    _toPartialString(this: SparqlQuery, options: any) {
       return this._getTemplateResult()._toPartialString(options)
     },
   }

--- a/src/lib/partials/DATA.ts
+++ b/src/lib/partials/DATA.ts
@@ -1,5 +1,5 @@
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
-import { SparqlQueryBuilder } from '../index'
+import { SparqlQuery } from '../index'
 import { concat } from '../TemplateResult'
 import { Term } from 'rdf-js'
 
@@ -8,7 +8,7 @@ export interface QuadDataBuilder<T, TTerm extends Term = Term> {
   DATA(strings: TemplateStringsArray, ...values: SparqlValue<TTerm>[]): T
 }
 
-export default <T extends SparqlQueryBuilder & QuadDataBuilder<T, TTerm>, TTerm extends Term = Term>(strings: TemplateStringsArray, values: SparqlValue<TTerm>[]): QuadDataBuilder<T, TTerm> => ({
+export default <T extends SparqlQuery & QuadDataBuilder<T, TTerm>, TTerm extends Term = Term>(strings: TemplateStringsArray, values: SparqlValue<TTerm>[]): QuadDataBuilder<T, TTerm> => ({
   quadData: sparql(strings, ...values),
   DATA(strings: TemplateStringsArray, ...values): T {
     return {

--- a/src/lib/partials/INSERT.ts
+++ b/src/lib/partials/INSERT.ts
@@ -1,6 +1,6 @@
 import { SparqlTemplateResult } from '@tpluscode/rdf-string/lib/sparql'
 import { sparql, SparqlValue } from '@tpluscode/rdf-string'
-import { SparqlQueryBuilder } from '../index'
+import { SparqlQuery } from '../index'
 import { concat } from '../TemplateResult'
 
 export interface InsertBuilder<T> {
@@ -9,7 +9,7 @@ export interface InsertBuilder<T> {
   INSERT(strings: TemplateStringsArray, ...values: SparqlValue[]): T
 }
 
-export default <T extends SparqlQueryBuilder & InsertBuilder<T>>(insertPatterns: SparqlTemplateResult | null = null): InsertBuilder<T> => ({
+export default <T extends SparqlQuery & InsertBuilder<T>>(insertPatterns: SparqlTemplateResult | null = null): InsertBuilder<T> => ({
   insertPatterns,
   insertClause(): SparqlTemplateResult {
     return sparql`INSERT{

--- a/src/lib/partials/LIMIT.ts
+++ b/src/lib/partials/LIMIT.ts
@@ -1,4 +1,4 @@
-import { SparqlQueryBuilder } from '../index'
+import { SparqlQuery } from '../index'
 
 export interface LimitOffsetBuilder<T> {
   offset: number | null
@@ -8,7 +8,7 @@ export interface LimitOffsetBuilder<T> {
   limitOffsetClause(): string
 }
 
-export default <T extends SparqlQueryBuilder & LimitOffsetBuilder<T>>(): LimitOffsetBuilder<T> => ({
+export default <T extends SparqlQuery & LimitOffsetBuilder<T>>(): LimitOffsetBuilder<T> => ({
   limit: null,
   offset: null,
   limitOffsetClause() {

--- a/src/lib/partials/ORDER.ts
+++ b/src/lib/partials/ORDER.ts
@@ -1,4 +1,4 @@
-import { SparqlQueryBuilder } from '../index'
+import { SparqlQuery } from '../index'
 import { Variable } from 'rdf-js'
 import { sparql, SparqlTemplateResult } from '@tpluscode/rdf-string'
 
@@ -17,7 +17,7 @@ export interface OrderBuilder<T> {
   ORDER(): OrderByBuilder<T>
 }
 
-export default <T extends SparqlQueryBuilder & OrderBuilder<T>>(): OrderBuilder<T> => ({
+export default <T extends SparqlQuery & OrderBuilder<T>>(): OrderBuilder<T> => ({
   orderConditions: [],
   ORDER(): OrderByBuilder<T> {
     return {

--- a/src/lib/partials/WHERE.ts
+++ b/src/lib/partials/WHERE.ts
@@ -1,5 +1,5 @@
 import { sparql, SparqlTemplateResult, SparqlValue } from '@tpluscode/rdf-string'
-import { SparqlQueryBuilder } from '../index'
+import { SparqlQuery } from '../index'
 import { concat } from '../TemplateResult'
 
 export interface WhereBuilder<T> {
@@ -8,7 +8,7 @@ export interface WhereBuilder<T> {
   WHERE(strings: TemplateStringsArray, ...values: SparqlValue[]): T
 }
 
-export default <T extends SparqlQueryBuilder & WhereBuilder<T>>({ required }: { required: boolean }): WhereBuilder<T> => ({
+export default <T extends SparqlQuery & WhereBuilder<T>>({ required }: { required: boolean }): WhereBuilder<T> => ({
   patterns: null,
   whereClause() {
     if (this.patterns) {

--- a/tests/execute.spec.ts
+++ b/tests/execute.spec.ts
@@ -4,11 +4,10 @@ import { ask, graph, select, update } from '../src/lib/execute'
 import { sparqlClient } from './_mocks'
 import { SparqlQuery } from '../src/lib'
 
-const builder: Omit<SparqlQuery<any>, '_getTemplateResult'> = {
+const builder: Omit<SparqlQuery, '_getTemplateResult'> = {
   build(): string {
     return ''
   },
-  execute: jest.fn(),
 }
 
 describe('execute', () => {


### PR DESCRIPTION
BREAKING CHANGE: will potentially break if `SparqlQuery<>` was imported and not only inferred